### PR TITLE
Fix php memory fatal error

### DIFF
--- a/php/src/Decrypter.php
+++ b/php/src/Decrypter.php
@@ -3,6 +3,7 @@
 require __DIR__."/BackupCipher.php";
 require __DIR__."/BackupKey.php";
 
+ini_set('memory_limit', '1024M');
 
 class Decrypter {
 


### PR DESCRIPTION
Fix the follow memory error:
```
Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 114462152 bytes) in Crypt12-Decryptor/php/src/Decrypter.php on line 62
```